### PR TITLE
Remove re

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests
-re
 datetime


### PR DESCRIPTION
Remove `re` as it's a [standard module](https://docs.python.org/3.8/library/re.html).