### PR TITLE
Remove datetime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests
 re
-datetime


### PR DESCRIPTION
`datetime` is a [standard Python module](https://docs.python.org/3.8/library/datetime.html).

Fixes #5